### PR TITLE
changing actionserver to bind all adapters instead of just localhost

### DIFF
--- a/idea-plugin/src/main/java/com/jetbrains/ide/streamdeck/ActionServer.java
+++ b/idea-plugin/src/main/java/com/jetbrains/ide/streamdeck/ActionServer.java
@@ -55,7 +55,7 @@ public final class ActionServer implements AutoCloseable {
             port = 21420;
         }
 
-        server = HttpServer.create(new InetSocketAddress(InetAddress.getByName(null), port), 5);
+        server = HttpServer.create(new InetSocketAddress(port), 5);
         server.createContext("/", new HandleHttpRequest());
 
         // Start the ActionServer on a separate thread from the rest of the framework


### PR DESCRIPTION
Currently, the action server is only binding to localhost, preventing the stream deck client from sending commands to a different machine running IntelliJ. I changed this to be a wildcard bind to the configured port.